### PR TITLE
Remembers last opened repository

### DIFF
--- a/BugHub for Mac/BugHub/BugHub/AppDelegate.m
+++ b/BugHub for Mac/BugHub/BugHub/AppDelegate.m
@@ -96,9 +96,13 @@
             }
         }
         
-        // If no repo windows were restored, show the repo picker window
-        if (!hasOpenRepoWindow)
-            [self openRepoChooser:nil];
+        if (!hasOpenRepoWindow) {
+            NSString* lastOpenedRepo = [[NSUserDefaults standardUserDefaults] stringForKey:@"lastOpenedRepository"];
+            // If no repo windows were restored, show the repo picker window
+            if(lastOpenedRepo) [self openRepoWindow:lastOpenedRepo];
+            else [self openRepoChooser:nil];
+        }
+        
     }
 
     [self checkAPIStatus];

--- a/BugHub for Mac/BugHub/BugHub/NewRepoWindowController.m
+++ b/BugHub for Mac/BugHub/BugHub/NewRepoWindowController.m
@@ -54,9 +54,12 @@
 
     if (!authenticatedUser)
         return;
-
-    [self.identifierField setStringValue:[NSString stringWithFormat:@"%@/", authenticatedUser]];
-    [self loadRepos:authenticatedUser];
+    
+    NSString* lastUsedUsername = [self usernameFromRepoIdentifier:[self lastOpenedRepository]];
+    NSString* userToBeUsed = lastUsedUsername ? lastUsedUsername : authenticatedUser;
+    
+    [self.identifierField setStringValue:[NSString stringWithFormat:@"%@/", userToBeUsed]];
+    [self loadRepos:userToBeUsed];
 }
 
 - (void)dealloc
@@ -219,6 +222,16 @@
     
 }
 
+-(NSString*)usernameFromRepoIdentifier:(NSString*)repoIdentifier
+{
+    NSInteger indexOfSlash = [repoIdentifier rangeOfString:@"/"].location;
+    
+    if (indexOfSlash == NSNotFound)
+        return nil;
+    
+    return [repoIdentifier substringToIndex:indexOfSlash];
+}
+
 - (void)controlTextDidChange:(NSNotification *)obj
 {
     if ([obj object] != self.identifierField)
@@ -227,12 +240,12 @@
     NSString *text = [self.identifierField stringValue];
     BOOL isValidID = [BHRepository isValidIdentifier:text];
     
-    NSInteger indexOfSlash = [text rangeOfString:@"/"].location;
+    NSString* username = [self usernameFromRepoIdentifier:text];
     
-    if (indexOfSlash == NSNotFound)
+    if (!username)
         return;
     
-    [self loadRepos:[text substringToIndex:indexOfSlash]];
+    [self loadRepos:username];
     [self filterRepos];
     
     [self.openButton setEnabled:isValidID];
@@ -248,6 +261,17 @@
     [(AppDelegate *)[NSApp delegate] windowControllerDidClose:self];
 }
 
+-(NSString*)lastOpenedRepository
+{
+    return [[NSUserDefaults standardUserDefaults] stringForKey:@"lastOpenedRepository"];
+}
+
+-(BOOL)rememberLastOpenedRepository:(NSString*)repositoryName
+{
+    [[NSUserDefaults standardUserDefaults]setObject:repositoryName forKey:@"lastOpenedRepository"];
+    return [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
 - (IBAction)openRepo:(id)sender
 {
     if (sender == self.repoListView)
@@ -257,7 +281,9 @@
         if (clickedRow == NSNotFound)
             return;
 
-        [(AppDelegate *)[NSApp delegate] openRepoWindow:[[_filteredRepos objectAtIndex:clickedRow] identifier]];
+        NSString* repoIdentifier = [[_filteredRepos objectAtIndex:clickedRow] identifier];
+        [(AppDelegate *)[NSApp delegate] openRepoWindow:repoIdentifier];
+        [self rememberLastOpenedRepository:repoIdentifier];
         [self closeWindow:nil];
         return;
     }
@@ -269,6 +295,7 @@
         return;
 
     [(AppDelegate *)[NSApp delegate] openRepoWindow:text];
+    [self rememberLastOpenedRepository:text];
     [self closeWindow:nil];
 }
 


### PR DESCRIPTION
Two features were implemented:
- When displaying the open repo dialog window, the repositories of the last used user are displayed instead of the authenticated user ones. This is useful if the user is part of multiple github groups / teams
- When starting the application, the last opened repository will be restored.
